### PR TITLE
Add support for XDG Base Directory Specification.

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -9,7 +9,7 @@ proc compile(srcfile: string, outdir: string, release: bool, verbose: bool) =
 
 proc configure() =
     when defined linux:
-        let configpath = getEnv("HOME") & "/.catnip/"
+        let configpath = getEnv("XDG_CONFIG_HOME") & "/catnip/"
     when defined windows:
         let configpath = "C:/Users/" & getEnv("USERPROFILE") & "/.catnip/"
 

--- a/src/catnip.nim
+++ b/src/catnip.nim
@@ -20,7 +20,7 @@ if paramCount() > 0:
             echo ""
             echo "Optins:"
             echo "    -h  --help                   Show help list"
-            echo "    -d  --distroid <DistroId>    Froce a DistroId"
+            echo "    -d  --distroid <DistroId>    Force a DistroId"
             echo "    -g  --grep     <StatName>    Get the stats value"
             echo ""
             echo "StatNames:"

--- a/src/catniplib/common/defs.nim
+++ b/src/catniplib/common/defs.nim
@@ -59,4 +59,4 @@ type
 const
     STATNAMES*  = @["username", "hostname", "uptime", "distro", "kernel", "desktop", "shell"]
     STATKEYS*   = @["icon", "name", "color"]
-    CONFIGPATH* = joinPath(getHomeDir(), ".catnip/config.toml")
+    CONFIGPATH* = joinPath(getConfigDir(), "catnip/config.toml")


### PR DESCRIPTION
This pull request adds support for the XDG Base Directory Specification on Linux (Aka placing the config file in ~/.config/catnip/ instead of ~/.catnip/), as well as fixes a small spelling mistake in the help list.