### PR TITLE
Update config.toml - Add Raspberry Pi OS

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -191,3 +191,17 @@ margin = [0, 0, 0,]
 
     [distroart.linuxmint]
     alias = "mint"
+
+    [distroart.raspbian]
+    margin = [2, 2, 3]
+    art    = [
+    "{GN}  __  __   ",
+    "{GN} (_\\)(/_)  ",
+    "{RD} (_(__)_)  ",
+    "{RD}(_(_)(_)_) ",
+    "{RD} (_(__)_)  ",
+    "{RD}   (__)    "
+    ]
+
+    [distroart.raspberrypios]
+    alias = "raspbian"


### PR DESCRIPTION
Added Raspberry Pi OS, the icon is from pfetch which got its icon from ufetch.
AFAIK newer Raspberry Pi OS installations just report as debian, so you can only get it with the "-d raspberrypios" command line.
At least that is how my 64-bit bookworm Raspberrypi OS works.

References:
https://github.com/dylanaraps/pfetch?tab=readme-ov-file
https://gitlab.com/jschx/ufetch/-/blob/main/ufetch-raspberrypios?ref_type=heads

![rpi_catnip](https://github.com/iinsertNameHere/catnip/assets/8122264/27885c7e-61ce-4ca0-b6a9-de4a9f30e6c7)
