### PR TITLE
Add support for Pop!_OS

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -243,7 +243,7 @@ margin = [0, 0, 0,]
     [distroart.endeavouros]
     alias = "endeavour"
 
-    [distroart.popos]
+    [distroart.pop!_os]
     margin = [1, 3, 3]
     art    = [
         "{CN}  ______             ",

--- a/config.toml
+++ b/config.toml
@@ -242,3 +242,16 @@ margin = [0, 0, 0,]
 
     [distroart.endeavouros]
     alias = "endeavour"
+
+    [distroart.popos]
+    margin = [1, 3, 3]
+    art    = [
+        "{CN}  ______             ",
+        "{CN}  \\   _ \\        __  ",
+        "{CN}   \\ \\ \\ \\      / /  ",
+        "{CN}    \\ \\_\\ \\    / /   ",
+        "{CN}     \\  ___\\  /_/    ",
+        "{CN}      \\ \\    _       ",
+        "{CN}     __\\_\\__(_)_     ",
+        "{CN}    (___________)    "
+    ]

--- a/config.toml
+++ b/config.toml
@@ -244,7 +244,7 @@ margin = [0, 0, 0,]
     alias = "endeavour"
 
     [distroart.pop!_os]
-    margin = [1, 3, 3]
+    margin = [1, 1, 2]
     art    = [
         "{CN}  ______             ",
         "{CN}  \\   _ \\        __  ",

--- a/config.toml
+++ b/config.toml
@@ -243,7 +243,7 @@ margin = [0, 0, 0,]
     [distroart.endeavouros]
     alias = "endeavour"
 
-    [distroart.pop!_os]
+    [distroart.popos]
     margin = [1, 1, 2]
     art    = [
         "{CN}  ______             ",


### PR DESCRIPTION
Artwork from ufetch but in teal since that is their current color.

![image](https://github.com/iinsertNameHere/catnip/assets/8122264/64eaf120-73e1-4401-81ad-977e5db2c95f)

