### PR TITLE
Handle aliases inside main distroart objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,19 +222,21 @@ art = [
 ```
 
 #### Alias
-The `alias` key can be used to reference an already existing DistroArt object.
-```
-alias = "arch"
-```
-This is also used in the `default` DistroArt object to set which art should be displayed by default.
+The `alias` key can be used to define alternate names that should also refer to the DistroArt Object.
 
-> **NOTE:** If you use the `alias` key, all other keys will have no effect.
+*Example in which 'test1' also referes to your new DistroArt object:*
+```
+alias = "test1"
+```
+
+This is also used to define the `default` DistroArt object, which defines what art should be displayed by default.
 
 ---
 
 *Example DistroArt object:*
 ```
 [distroart.test]
+alias = "test1"
 margin = [3, 3 ,3]
 art = [
   "Test",

--- a/config.toml
+++ b/config.toml
@@ -31,10 +31,8 @@ margin = [0, 0, 0,]
 ##         Distro ASCII-Art Config          ##
 ##############################################
 [distroart]
-    [distroart.default]
-    alias = "catnip"
-
     [distroart.catnip]
+    alias  = "default"
     margin = [1, 2, 2]
     art    = [
         "(GN)          ⣀⣀⣠⣠⣶⠦⢴⣦⣀⣠⣀  ",
@@ -179,6 +177,7 @@ margin = [0, 0, 0,]
     ]
 
     [distroart.mint]
+    alias = "linuxmint"
     margin = [2, 2, 4]
     art    = [
         "{CN} ___________ ",
@@ -190,10 +189,8 @@ margin = [0, 0, 0,]
         "{CN}  \\_________/"
     ]
 
-    [distroart.linuxmint]
-    alias = "mint"
-
     [distroart.raspbian]
+    alias = "raspberrypios"
     margin = [2, 2, 3]
     art    = [
         "{GN}  __  __   ",
@@ -203,9 +200,6 @@ margin = [0, 0, 0,]
         "{RD} (_(__)_)  ",
         "{RD}   (__)    "
     ]
-
-    [distroart.raspberrypios]
-    alias = "raspbian"
 
     [distroart.android]
     margin = [2, 2, 2]
@@ -231,6 +225,7 @@ margin = [0, 0, 0,]
     ]
 
     [distroart.endeavour]
+    alias = "endeavour"
     margin = [2, 2, 3]
     art    = [
         "{MA}       /\\     ",
@@ -241,10 +236,8 @@ margin = [0, 0, 0,]
         "{CN}/____--       "
     ]
 
-    [distroart.endeavouros]
-    alias = "endeavour"
-
     [distroart.pop]
+    alias = "popos, pop_os"
     margin = [1, 1, 2]
     art    = [
         "{CN}  ______             ",

--- a/src/catnip.nim
+++ b/src/catnip.nim
@@ -9,9 +9,9 @@ import strutils
 
 proc getAllDistros(): seq[string] =
     let distroart = LoadConfig(CONFIGPATH).distroart
-    for distro in distroart.getTable().keys:
-        if not distroart[distro].contains("alias"): # Skip alias definitions
-            result.add(distro)
+    for k in distroart.keys:
+        if not distroart[k].isAlias:
+            result.add(k)
 
 # Debug code for execution time
 when not defined release: 

--- a/src/catniplib/common/config.nim
+++ b/src/catniplib/common/config.nim
@@ -1,10 +1,13 @@
 import "toml"
-from "defs" import Config, STATNAMES, STATKEYS
+from "defs" import Config, STATNAMES, STATKEYS, Logo
 from os import fileExists
 import strformat
+import strutils
 
 proc LoadConfig*(path: string): Config =
     ## Lads a config file and validates it
+    
+    # 1. Validate the config file
     
     if not fileExists(path):
         echo &"ERROR: {path} - file not found!"
@@ -25,14 +28,11 @@ proc LoadConfig*(path: string): Config =
     if tcfg["stats"].contains("colors"):
         for statkey in STATKEYS & @["symbol"]:
             if not tcfg["stats"]["colors"].contains(statkey):
-                    echo &"ERROR: {path}:stats:colors - missing '" & statkey & "'!"
-                    quit(1)
+                echo &"ERROR: {path}:stats:colors - missing '" & statkey & "'!"
+                quit(1)
 
     if not tcfg.contains("distroart"):
         echo &"ERROR: {path} - missing 'distroart'!"
-        quit(1)
-    if not tcfg["distroart"].contains("default"):
-        echo &"ERROR: {path}:distroart - missing 'default'!"
         quit(1)
 
     if not tcfg.contains("misc"):
@@ -63,6 +63,54 @@ proc LoadConfig*(path: string): Config =
         echo &"ERROR: {path}:misc:figletLogos - missing 'margin'!"
         quit(1)
     
+    ###############################################################
+    # 2. Fill out the result
+
+    for distro in tcfg["distroart"].getTable().keys:
+        if not tcfg["distroart"][distro].contains("margin"):
+            echo &"ERROR: {path}:distroart:{distro} - missing 'margin'!"
+            quit(1)
+        if not tcfg["distroart"][distro].contains("art"):
+            echo &"ERROR: {path}:distroart:{distro} - missing 'art'!"
+            quit(1)
+        
+        # Generate Logo Objects for each logo in config
+        var newLogo: Logo 
+        var tmargin = tcfg["distroart"][distro]["margin"]
+        newLogo.margin = [tmargin[0].getInt(), tmargin[1].getInt(), tmargin[2].getInt()]
+        for line in tcfg["distroart"][distro]["art"].getElems:
+            newLogo.art.add(line.getStr())
+
+        if tcfg["distroart"][distro].contains("alias"): # Inflate distroart table with alias if exists
+            let raw_alias_list = tcfg["distroart"][distro]["alias"].getStr().split(",")
+            var alias_list: seq[string]
+            for alias in raw_alias_list:
+                alias_list.add(alias.strip())
+            
+            newLogo.isAlias = true
+
+            # Chars that a alias can contain
+            let allowedNameChars = {'A' .. 'Z', 'a' .. 'z', '0' .. '9', '_'}
+
+            for name in alias_list:
+                if result.distroart.hasKey(name):
+                    echo &"ERROR: {path}:distroart:{distro} - alias '{name}' already exists!"
+                    quit(1)
+                
+                for c in name: # Check if name is a valid alias
+                    if not (c in allowedNameChars):
+                        echo &"ERROR: {path}:distroart:{distro} - '{name}' is not a valid alias!"
+                        quit(1)
+
+                result.distroart[name] = newLogo # Add alias to result
+
+        newLogo.isAlias = false
+
+        result.distroart[distro] = newLogo # Add distroart obj to result
+
+    if not result.distroart.contains("default"): # Validate that default alias exists
+        echo &"ERROR: {path}:distroart - missing 'default'!"
+        quit(1)
+
     result.stats = tcfg["stats"]
-    result.distroart = tcfg["distroart"]
     result.misc = tcfg["misc"]

--- a/src/catniplib/common/defs.nim
+++ b/src/catniplib/common/defs.nim
@@ -1,5 +1,6 @@
 import "toml"
 import os
+import tables
 
 type
     Color* = string
@@ -23,6 +24,7 @@ type
     Logo* = object
         margin*: Margin
         art*: seq[string]
+        isAlias*: bool
 
     Stat* = object
         icon*: string
@@ -54,7 +56,7 @@ type
 
     Config* = object
         stats*: TomlValueRef
-        distroart*: TomlValueRef
+        distroart*: OrderedTable[string, Logo]
         misc*: TomlValueRef
 
 const

--- a/src/catniplib/fetch.nim
+++ b/src/catniplib/fetch.nim
@@ -27,17 +27,7 @@ proc fetchSystemInfo*(distroId: string = "nil"): FetchInfo =
             if not config.distroart.contains(distroId):
                 distroId = "default"
 
-        
-        if config.distroart[distroId].contains("alias"):
-            let talias = config.distroart[distroId]["alias"]
-            distroId = talias.getStr()
-            if not config.distroart.contains(distroId):
-                distroId = "default"
-
-        let tmargin = config.distroart[distroId]["margin"]
-        result.logo.margin = [tmargin[0].getInt(), tmargin[1].getInt(), tmargin[2].getInt()]
-        for line in config.distroart[distroId]["art"].getElems:
-            result.logo.art.add(line.getStr())
+        result.logo = config.distroart[distroId]
 
     else: # Generate logo using figlet
         when defined linux:


### PR DESCRIPTION
Handle aliases inside main distroart.

*Old System*
```toml
[distroart.pop]
margin = [1, 1, 2]
art    = [
    "{CN}  ______             ",
    "{CN}  \\   _ \\        __  ",
     "{CN}   \\ \\ \\ \\      / /  ",
     "{CN}    \\ \\_\\ \\    / /   ",
     "{CN}     \\  ___\\  /_/    ",
     "{CN}      \\ \\    _       ",
     "{CN}     __\\_\\__(_)_     ",
     "{CN}    (___________)    "
 ]
 
 [distroart.popos]
 alias = "pop"
 
 [distroart.pop_os]
 alias = "pop"
```

*New System*
```toml
[distroart.pop]
alias = "popos, pop_os"
margin = [1, 1, 2]
art    = [
    "{CN}  ______             ",
    "{CN}  \\   _ \\        __  ",
     "{CN}   \\ \\ \\ \\      / /  ",
     "{CN}    \\ \\_\\ \\    / /   ",
     "{CN}     \\  ___\\  /_/    ",
     "{CN}      \\ \\    _       ",
     "{CN}     __\\_\\__(_)_     ",
     "{CN}    (___________)    "
 ]
```