### PR TITLE
Made it so that the default config directory on Windows is AppData\Local\catnip

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $ catnip --help
 ## 📒 Configuration
 > **The config files are located at:**
 > -  `~/.config/catnip`: Linux
-> -  `C:\Users\%USERNAME%\catnip`: Windows
+> -  `C:\Users\%USERNAME%\AppData\Local\catnip`: Windows
 
 <br>
 

--- a/config.nims
+++ b/config.nims
@@ -19,7 +19,7 @@ proc configure() =
             configpath = XDG_CONFIG_HOME & "/catnip/"
         
     when defined windows:
-        let configpath = "C:/Users/" & getEnv("USERPROFILE") & "/.catnip/"
+        let configpath = "C:/Users/" & getEnv("USERPROFILE") & "AppData/Local/catnip/"
 
     echo "Creating " & configpath
     mkdir(configpath)


### PR DESCRIPTION
I don't use Windows, so this might not work. (It probably does though.)