### PR TITLE
Added Catnip(1) man file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 catnip
 *.exe
 *.sh
+*.gz

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ I created `Catnip🌿` as a playful, simple system-information **concatenation**
 Dependencies (Linux only):
 - pcre
 - figlet
+- gzip
 ```
 
 **2.** Clone the repo:

--- a/config.nims
+++ b/config.nims
@@ -16,13 +16,13 @@ proc configure() =
     when defined linux:
         var configpath = ""
 
-        # Use XDG_CONFIG_HOME only if it is defined. Else use ~/.confg 
+        # Use XDG_CONFIG_HOME only if it is defined. Else use ~/.confg
         let XDG_CONFIG_HOME = getEnv("XDG_CONFIG_HOME")
         if XDG_CONFIG_HOME == "":
             configpath = getEnv("HOME") & "/.config/catnip/"
         else:
             configpath = XDG_CONFIG_HOME & "/catnip/"
-        
+
     when defined windows:
         let configpath = "C:/Users/" & getEnv("USERPROFILE") & "AppData/Local/catnip/"
 
@@ -48,15 +48,17 @@ task install_cfg, "Installs the config files":
     configure()
 
 when defined linux:
-    task install_bin, "Installs the bin file inside /usr/local/bin":
+    task install_linux, "Installs the bin file and man page:":
         echo "\e[36;1mInstalling\e[0;0m bin file"
         echo &"Copying {thisDir()}/bin/catnip to /usr/local/bin"
         exec &"sudo cp {thisDir()}/bin/catnip /usr/local/bin"
+        echo &"\e[36;1mInstalling\e[0;0m man page"
+        exec &"gzip -k {thisDir()}/docs/catnip.1 && sudo cp {thisDir()}/docs/catnip.1.gz /usr/share/man/man1"
 
-    task install, "'release', 'install_bin' and 'install_cfg'":
+    task install, "'release', 'install_linux' and 'install_cfg'":
         releaseTask()
         install_cfgTask()
-        install_binTask()
+        install_linuxTask()
 
 task setup, "'release' and 'install_cfg'":
     releaseTask()

--- a/docs/catnip.1
+++ b/docs/catnip.1
@@ -1,0 +1,52 @@
+.TH catnip 1 "2024-03-23" "1.0" "User Commands"
+.SH NAME
+Catnip \- A highly customizable systemfetch written in nim
+.SH SYNOPSIS
+.B catnip
+.B -d
+.RI [\| DistroId \|]
+.br
+.B catnip
+.B -g
+.RI [\| StatName \|]
+.br
+.B catnip
+.B -l
+.RI [\| Layout \|]
+.SH DESCRIPTION
+Catnip is a simple system-information concatenation tool writen with nim. It has the ability to alter the names and colors of the statistics via its configuration file.
+.SH OPTIONS
+.TP
+\fB\-c\fR, \fB\-\-config\fR=File
+Uses a custom location for the config file
+.TP
+\fB\-d\fR, \fB\-\-distroid\fR=DistroId
+Set which DistroId to use
+.TP
+\fB\-g\fR, \fB\-\-grep\fR=StatName
+Get the specified stats value
+.TP
+\fB\-l\fR, \fB\-\-layout\fR=Layout
+Overwrite layout config value
+.TP
+\fB\-fe\fR, \fB\-\-figletLogos.enable\fR=On/Off
+Overwrite figletLogos mode
+.TP
+\fB\-ff\fR, \fB\-\-figletLogos.font\fR=Font
+Overwrite figletLogos font
+.TP
+\fB\-fm\fR, \fB\-\-figletLogos.margin\fR=Margin
+Overwrite figletLogos margin
+.SH FILES
+.TP
+\fB\.config/catnip/config.toml\fR
+Configuration file
+.TP
+\fB\.config/catnip/distros.toml\fR
+Distribution logos file
+.SH BUGS
+.TP
+Report all bugs to https://github.com/iinsertNameHere/catnip/issues
+.SH SEE ALSO
+.TP
+\fBfiglet\fP(6)

--- a/src/catnip.nim
+++ b/src/catnip.nim
@@ -28,7 +28,7 @@ proc printHelp(cfg: Config) =
     echo "    -m  --margin               <Margin>      Overwrite margin value for the displayed logo (Example: 1,2,3)"
     echo "    -l  --layout               <Layout>      Overwrite layout config value [Inline,LogoOnTop,ArtOnTop]"
     echo ""
-    echo "    -fe --figletLogos.enable   <on/off>      Overwrite figletLogos enable"
+    echo "    -fe --figletLogos.enable   <on/off>      Overwrite figletLogos mode"
     echo "    -fm --figletLogos.margin   <Margin>      Overwrite figletLogos margin (Example: 1,2,3)"
     echo "    -ff --figletLogos.font     <Font>        Overwrite figletLogos font"
     echo ""


### PR DESCRIPTION
This PR adds a man file for Catnip (for its options).
I might work on Catnip(5) in the future if I have time. (man file about configuring Catnip)
As man files are installed by compressing them with `gzip` and copying the file to `/usr/share/man`, I added it to the dependency list and also changed the `install_bin` task.