### PR TITLE
Make catnip check other envs if $XDG_CURRENT_DESKTOP

### DIFF
--- a/src/catniplib/platform/probe.nim
+++ b/src/catniplib/platform/probe.nim
@@ -93,14 +93,10 @@ proc getDesktop*(): string =
             result = "Headless"
 
     if result == "": # Check $XDG_SESSION_DESKTOP and $DESKTOP_SESSION
-        result2 = getEnv("XDG_SESSION_DESKTOP")
-        if result2 != "":
-            result = result2
-        if result2 == "":
-            result3 = getEnv("DESKTOP_SESSION") 
-            if result3 != "":
-                result = result3
-            if result3 == "":
+        result = getEnv("XDG_SESSION_DESKTOP")
+        if result == "":
+            result = getEnv("DESKTOP_SESSION")
+            if result == "":
                 result = "Unknown"
 
 proc getMemory*(mb: bool): string =

--- a/src/catniplib/platform/probe.nim
+++ b/src/catniplib/platform/probe.nim
@@ -92,8 +92,16 @@ proc getDesktop*(): string =
         if getTerminal() == "tty":
             result = "Headless"
 
-    if result == "": # Unknown desktop
-            result = "Unknown"
+    if result == "": # Check $XDG_SESSION_DESKTOP and $DESKTOP_SESSION
+        result2 = getEnv("XDG_SESSION_DESKTOP")
+        if result2 != "":
+            result = result2
+        if result2 == "":
+            result3 = getEnv("DESKTOP_SESSION") 
+            if result3 != "":
+                result = result3
+            if result3 == "":
+                result = "Unknown"
 
 proc getMemory*(mb: bool): string =
     ## Returns statistics about the memory


### PR DESCRIPTION
Made it so getDesktop checks both XDG_SESSION_DESKTOP and DESKTOP_SESSION before erroring to unknown. 

Closes #61 

Tested with Arch Linux on i3 w/ debug logs