### PR TITLE
Update Github Actions file

### DIFF
--- a/.github/workflows/test-catnip.yml
+++ b/.github/workflows/test-catnip.yml
@@ -1,4 +1,4 @@
-name: build-test
+name: test-catnip
 on:
   push:
   pull_request:
@@ -7,15 +7,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: 'Checkout Repository'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: 'Install Nim'
       uses: iffy/install-nim@v5
     - name: 'Setup Nim'
       uses: jiro4989/setup-nim-action@v1
       with:
-        nim-version: '2.x'
+        nim-version: 'stable'
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: 'Build Catnip'
-      run: nim release
+      run: nim debug
     - name: 'Install Figlet'
       run: sudo apt-get install figlet
     - name: 'Run Tests'


### PR DESCRIPTION
### Is your pull request linked to an existing issue?
#77 

### What is your pull request about?:
I changed the following things:
1. Updated actions/checkout to v4. (it was v3 previously)
2.Renamed the file from build-test to test-catnip, since it isn't just about building Catnip anymore.
3. Changed jiro4989/setup-nim-action@v1 to setup the stable version of Nim, as well as use the secret Github token.
4. Changed `nim release` to `nim debug` to give further information if the test ever fails at that stage.

### Any other disclosures/notices/things to add?
The ${{ secrets.GITHUB_TOKEN }} is created when the Github Action thing was set up, and I'm sure that no one has access to it,  (except for the runner, of course) so it's safe to include.

See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret