### PR TITLE
Add opensuse distro logo and configurable margin top

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -28,6 +28,7 @@ colors    = {icon = " ", name = "colors", color = "!DT!", symbol = ""}
 ##############################################
 [misc]
 layout = "Inline" # [Inline, ArtOnTop, StatsOnTop]
+stats_margin_top = 3
 
 [misc.figletLogos]
 enable = false

--- a/config/distros.toml
+++ b/config/distros.toml
@@ -201,6 +201,28 @@ art    = [
 ]
 
 ### O ###
+[opensuse]
+margin = [0, 0, 2,]
+art    = [
+    "!DT!           .;ldkO0000Okdl;.           ",
+    "!DT!       .;d00xl:^''''''^:ok00d;.       ",
+    "!DT!     .d00l'                'o00d.     ",
+    "!DT!   .d0Kd'  (GN)Okxol:;,.          !DT!:O0d.   ",
+    "!DT!  .OK(GN)KKK0kOKKKKKKKKKKOxo:,      !DT!lK0.  ",
+    "!DT! ,0K(GN)KKKKKKKKKKKKKKKOP^!DT!,,,(GN)^dx:    !DT!;OO, ",
+    "!DT!.OK(GN)KKKKKKKKKKKKKKKk'!DT!.oOPPb.(GN)'Ok.   !DT!cKO.",
+    "!DT!:KK(GN)KKKKKKKKKKKKKKK: !DT!kKx..dd (GN)lKd   !DT!'OK:",
+    "!DT!dKK(GN)KKKKKKKKKOxOKKKd !DT!^OKKKO' (GN)kKKc   !DT!dKd",
+    "!DT!dKK(GN)KKKKKKKKKK;.;oOKx,..!DT!^(GN)..;kKKKO.  !DT!dKd",
+    "!DT!:KK(GN)KKKKKKKKKK0o;...^cdxxOK0O/^^'  !DT!.OK:",
+    "!DT! kKK(GN)KKKKKKKKKKKKKOx;,,......,;od  !DT!lKk ",
+    "!DT! '0K(GN)KKKKKKKKKKKKKKKKKKKK00KKOo^  !DT!c00' ",
+    "!DT!  'kK(GN)KKOxddxkOO00000Okxoc;''   !DT!.dKk'  ",
+    "!DT!    l0Ko.                    .c00l'   ",
+    "!DT!     'l0Kk:.              .;xK0l'     ",
+    "!DT!        'lkK0xl:;,,,,;:ldO0kl'        ",
+    "!DT!            '^:ldxkkkkxdl:^'          "
+]
 
 ### P ###
 [pop]

--- a/src/catniplib/drawing/render.nim
+++ b/src/catniplib/drawing/render.nim
@@ -59,8 +59,12 @@ proc Render*(config: Config, fetchinfo: FetchInfo) =
 
     let ORDERED_STATNAMES = keys & delta
 
+    var stats_margin_top = 0
+    if config.misc.contains("stats_margin_top"):
+        stats_margin_top = config.misc["stats_margin_top"].getInt()
+
     # Build the stat_block buffer
-    var stats_block = buildStatBlock(ORDERED_STATNAMES, stats, fetchinfo)
+    var stats_block = buildStatBlock(ORDERED_STATNAMES, stats, fetchinfo, stats_margin_top)
 
     # Merge buffers and output
     case layout:

--- a/src/catniplib/generation/utils.nim
+++ b/src/catniplib/generation/utils.nim
@@ -17,10 +17,14 @@ proc reallen*(s: string): int =
     # Get the length of a string without ansi color codes
     result = Uncolorize(s).runeLen
 
-proc buildStatBlock*(stat_names: seq[string], stats: Stats, fi: FetchInfo): seq[string] =
+proc buildStatBlock*(stat_names: seq[string], stats: Stats, fi: FetchInfo, margin_top: int): seq[string] =
     # Build output lines from Stats object and FetchInfo object
 
     var sb: seq[string]
+
+    for idx in countup(1, margin_top):
+        sb.add("")
+
     proc addStat(stat: Stat, value: string) =
         # Function to add a stat/value pair to the result
         var line = stat.icon & " " & stat.name

--- a/src/catniplib/global/definitions.nim
+++ b/src/catniplib/global/definitions.nim
@@ -64,6 +64,7 @@ const
         "ubuntu": "apt",
         "debian": "apt",
         "opensuse": "zypper",
+        "opensuse-tumbleweed": "zypper",
         "arch": "pacman",
     }.toOrderedTable
     PKGCOUNTCOMMANDS* = {


### PR DESCRIPTION
I added a logo for the openSUSE distro.
The logo is a bit bigger than the others.
That's why I also added a configurable margin_top to the stats block. It's an optional config property because it has a default value of "0" if the config property does not exist.
