### PR TITLE
[W.I.P] Added package count for a lot of distros

### DIFF
--- a/config/distros.toml
+++ b/config/distros.toml
@@ -310,16 +310,6 @@ art    = [
 ]
 
 ### W ###
-[windows]
-margin = [2, 2, 4,]
-art    = [
-    "[RD]       [GN]       ",
-    "[RD]       [GN]       ",
-    "[RD]       [GN]       ",
-    "[BE]       [YW]       ",
-    "[BE]       [YW]       ",
-    "[BE]       [YW]       ",
-]
 
 ### X ###
 

--- a/src/catniplib/global/definitions.nim
+++ b/src/catniplib/global/definitions.nim
@@ -60,17 +60,30 @@ const
     
     # Pkg Manager
     PKGMANAGERS*  = {
+        "gentoo": "emerge",
         "fedora": "dnf",
         "redhat": "yum",
         "centos": "yum",
         "ubuntu": "apt",
         "debian": "apt",
+        "kali": "apt",
+        "mint": "apt",
+        "pop": "apt",
+        "raspbian": "apt",
+        "zorin": "apt",
         "opensuse": "zypper",
         "opensuse-tumbleweed": "zypper",
         "arch": "pacman",
+        "archcraft": "pacman",
+        "artix": "pacman",
+        "manjaro": "pacman",
+        "endavour": "pacman",
         "alpine": "apk",
+        "void": "xbps",
     }.toOrderedTable
     PKGCOUNTCOMMANDS* = {
+        "xbps": "xbps-query -l | wc -l",
+        "emerge": "equery list --duplicates '*' | wc -l",
         "dnf": "dnf list installed | wc -l",
         "yum": "yum list installed | wc -l",
         "apt": "dpkg-query -l | grep '^ii' | wc -l",


### PR DESCRIPTION
### Is your pull request linked to an existing issue?
No.

### What is your pull request about?:
Added package managers:
- xbps
- emerge

Added distros:
- gentoo
- void
- kali linux
- linux mint
- popOS
- zorin OS
- raspbian
- archcraft
- artix
- manjaro
- endavour

### Any other disclosures/notices/things to add?
Can someone test out Void and Gentoo and see if the package count stat works?