### PR TITLE
Added package count for a lot of distros (Part 2)

### DIFF
--- a/src/catniplib/global/definitions.nim
+++ b/src/catniplib/global/definitions.nim
@@ -83,7 +83,7 @@ const
     }.toOrderedTable
     PKGCOUNTCOMMANDS* = {
         "xbps": "xbps-query -l | wc -l",
-        "emerge": "equery list --duplicates '*' | wc -l",
+        "emerge": "equery list '*' | wc -l",
         "dnf": "dnf list installed | wc -l",
         "yum": "yum list installed | wc -l",
         "apt": "dpkg-query -l | grep '^ii' | wc -l",

--- a/src/catniplib/global/definitions.nim
+++ b/src/catniplib/global/definitions.nim
@@ -69,6 +69,7 @@ const
         "kali": "apt",
         "mint": "apt",
         "pop": "apt",
+        "android": "apt",
         "raspbian": "apt",
         "zorin": "apt",
         "opensuse": "zypper",

--- a/src/catniplib/global/definitions.nim
+++ b/src/catniplib/global/definitions.nim
@@ -80,8 +80,10 @@ const
         "endavour": "pacman",
         "alpine": "apk",
         "void": "xbps",
+        "nixos": "nix",
     }.toOrderedTable
     PKGCOUNTCOMMANDS* = {
+        "nix": "nix-env --query --installed",
         "xbps": "xbps-query -l | wc -l",
         "emerge": "equery list '*' | wc -l",
         "dnf": "dnf list installed | wc -l",


### PR DESCRIPTION
### Is your pull request linked to an existing issue?
#95 (PR)

### What is your pull request about?:
I tested the new package stat for `xbps` and `emerge` https://github.com/iinsertNameHere/catnip/pull/95#issue-2319289238 and the `emerge` one was wrong, so i corrected it.

Android (via Termux) uses apt, so I simply added it to the apt list.

I also added the package stat for `nix`, and tested it.

### Any other disclosures/notices/things to add?
No.
